### PR TITLE
Development (#20)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.2.14 (02-May-2023)
+
+- Fixed an issue where an attempt to read a media stream sometimes resulted in a `403 Forbidden` error.
+
 ## v6.2.13 (27-Apr-2023)
 
 - Improved support for older target frameworks via polyfills.
@@ -32,7 +36,7 @@
 
 ## v6.2.6 (11-Feb-2023)
 
-- Fixed an issue where an attempt to retrieve a stream occasionally failed with a 403 Forbidden error.
+- Fixed an issue where an attempt to retrieve a stream occasionally failed with a `403 Forbidden` error.
 - [Converter] Fixed an issue where downloading a video as an `mp3` file sometimes resulted in lower bitrate than the original audio.
 
 ## v6.2.5 (06-Dec-2022)
@@ -262,14 +266,14 @@ Thanks to [@d4n3436](https://github.com/d4n3436), [@Benjamin K.](https://github.
 - Improved exceptions, exception messages, and everything related to exceptions. Additionally, all exception types now derive from `YoutubeExplodeException`, making them easier to catch.
 - Added built-in retry mechanisms to work around transient errors on YouTube's side.
 - Improved resilience of the library in general.
-- Fixed an issue where attempts to download some videos were periodically causing 403 Forbidden.
+- Fixed an issue where attempts to download some videos were periodically causing `403 Forbidden`.
 - Fixed a metric ton of YouTube-related issues.
 - Many, many others improvements that I didn't think to mention.
 - Dropped .NET Framework v4.5 target in favor of v4.6.1 and .NET Standard v1.1 target in favor of v2.0.
 
 ## v4.7.16 (16-Mar-2020)
 
-- Fixed an issue where attempts to download some videos were periodically causing 403 Forbidden.
+- Fixed an issue where attempts to download some videos were periodically causing `403 Forbidden`.
 
 ## v4.7.15 (11-Mar-2020)
 
@@ -430,7 +434,7 @@ Thanks to [@d4n3436](https://github.com/d4n3436), [@Benjamin K.](https://github.
 
 ## v4.3.1 (28-Aug-2018)
 
-- Fixed an issue where retrieving some streams may throw a 403 HTTP error due to recent YouTube changes.
+- Fixed an issue where retrieving some streams may throw a `403 Forbidden` error due to recent YouTube changes.
 
 ## v4.3 (25-Jul-2018)
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>7.0.5</Version>
+    <Version>7.0.6</Version>
     <Company>Tyrrrz, GoffinCedric</Company>
     <Copyright>Copyright (C) Oleksii Holub, Goffin Cédric</Copyright>
     <LangVersion>latest</LangVersion>

--- a/YoutubeReExplode.Tests/ChannelSpecs.cs
+++ b/YoutubeReExplode.Tests/ChannelSpecs.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using YoutubeReExplode;
 using YoutubeReExplode.Common;
 using YoutubeReExplode.Tests.TestData;
 

--- a/YoutubeReExplode.Tests/ClosedCaptionSpecs.cs
+++ b/YoutubeReExplode.Tests/ClosedCaptionSpecs.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using YoutubeReExplode;
 using YoutubeReExplode.Tests.TestData;
 using YoutubeReExplode.Tests.Utils;
 

--- a/YoutubeReExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeReExplode.Tests/PlaylistSpecs.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
-using YoutubeReExplode;
 using YoutubeReExplode.Common;
 using YoutubeReExplode.Exceptions;
 using YoutubeReExplode.Tests.TestData;

--- a/YoutubeReExplode.Tests/SearchSpecs.cs
+++ b/YoutubeReExplode.Tests/SearchSpecs.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using YoutubeReExplode;
 using YoutubeReExplode.Common;
 
 namespace YoutubeReExplode.Tests;

--- a/YoutubeReExplode.Tests/StreamSpecs.cs
+++ b/YoutubeReExplode.Tests/StreamSpecs.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
-using YoutubeReExplode;
 using YoutubeReExplode.Exceptions;
 using YoutubeReExplode.Tests.TestData;
 using YoutubeReExplode.Tests.Utils;
@@ -80,7 +79,7 @@ public class StreamSpecs
         manifest.Streams.Should().NotBeEmpty();
     }
 
-    [Fact]
+    [Fact(Skip = "Preview video ID is not always available")]
     public async Task I_cannot_get_the_list_of_available_streams_on_a_paid_video()
     {
         // Arrange
@@ -268,7 +267,7 @@ public class StreamSpecs
         var youtube = new YoutubeClient();
 
         // Act & assert
-        var ex = await Assert.ThrowsAsync<YoutubeExplodeException>(async () =>
+        var ex = await Assert.ThrowsAsync<YoutubeReExplodeException>(async () =>
             await youtube.Videos.Streams.GetHttpLiveStreamUrlAsync(VideoIds.Normal)
         );
 

--- a/YoutubeReExplode.Tests/VideoSpecs.cs
+++ b/YoutubeReExplode.Tests/VideoSpecs.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
-using YoutubeReExplode;
 using YoutubeReExplode.Common;
 using YoutubeReExplode.Exceptions;
 using YoutubeReExplode.Tests.TestData;

--- a/YoutubeReExplode/Bridge/ChannelPage.cs
+++ b/YoutubeReExplode/Bridge/ChannelPage.cs
@@ -1,7 +1,7 @@
 using System;
 using AngleSharp.Html.Dom;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/ClosedCaptionTrackResponse.cs
+++ b/YoutubeReExplode/Bridge/ClosedCaptionTrackResponse.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/DashManifest.cs
+++ b/YoutubeReExplode/Bridge/DashManifest.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 
@@ -16,13 +16,13 @@ internal partial class DashManifest
         _content
             .Descendants("Representation")
             // Skip non-media representations (like "rawcc")
-            // https://github.com/Tyrrrz/YoutubeReExplode/issues/546
+            // https://github.com/Tyrrrz/YoutubeExplode/issues/546
             .Where(x => x
                 .Attribute("id")?
                 .Value
                 .All(char.IsDigit) == true)
             // Skip segmented streams
-            // https://github.com/Tyrrrz/YoutubeReExplode/issues/159
+            // https://github.com/Tyrrrz/YoutubeExplode/issues/159
             .Where(x => x
                 .Descendants("Initialization")
                 .FirstOrDefault()?

--- a/YoutubeReExplode/Bridge/InitialData.cs
+++ b/YoutubeReExplode/Bridge/InitialData.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/PlayerResponse.cs
+++ b/YoutubeReExplode/Bridge/PlayerResponse.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/PlayerSource.cs
+++ b/YoutubeReExplode/Bridge/PlayerSource.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Bridge.Cipher;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/PlaylistBrowseResponse.cs
+++ b/YoutubeReExplode/Bridge/PlaylistBrowseResponse.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/PlaylistNextResponse.cs
+++ b/YoutubeReExplode/Bridge/PlaylistNextResponse.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/PlaylistVideoData.cs
+++ b/YoutubeReExplode/Bridge/PlaylistVideoData.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/SearchResponse.cs
+++ b/YoutubeReExplode/Bridge/SearchResponse.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/ThumbnailData.cs
+++ b/YoutubeReExplode/Bridge/ThumbnailData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Bridge/VideoWatchPage.cs
+++ b/YoutubeReExplode/Bridge/VideoWatchPage.cs
@@ -4,8 +4,8 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Bridge;
 

--- a/YoutubeReExplode/Channels/ChannelClient.cs
+++ b/YoutubeReExplode/Channels/ChannelClient.cs
@@ -4,11 +4,11 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Bridge;
 using YoutubeReExplode.Common;
 using YoutubeReExplode.Exceptions;
 using YoutubeReExplode.Playlists;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Channels;
 
@@ -33,15 +33,15 @@ public class ChannelClient
     {
         var channelId =
             channelPage.Id ??
-            throw new YoutubeExplodeException("Could not extract channel ID.");
+            throw new YoutubeReExplodeException("Could not extract channel ID.");
 
         var title =
             channelPage.Title ??
-            throw new YoutubeExplodeException("Could not extract channel title.");
+            throw new YoutubeReExplodeException("Could not extract channel title.");
 
         var logoUrl =
             channelPage.LogoUrl ??
-            throw new YoutubeExplodeException("Could not extract channel logo URL.");
+            throw new YoutubeReExplodeException("Could not extract channel logo URL.");
 
         var logoSize = Regex
             .Matches(logoUrl, @"\bs(\d+)\b")

--- a/YoutubeReExplode/Channels/ChannelController.cs
+++ b/YoutubeReExplode/Channels/ChannelController.cs
@@ -27,7 +27,7 @@ internal class ChannelController
                 if (retriesRemaining > 0)
                     continue;
 
-                throw new YoutubeExplodeException(
+                throw new YoutubeReExplodeException(
                     "Channel page is broken. " +
                     "Please try again in a few minutes."
                 );

--- a/YoutubeReExplode/Exceptions/PlaylistUnavailableException.cs
+++ b/YoutubeReExplode/Exceptions/PlaylistUnavailableException.cs
@@ -3,7 +3,7 @@ namespace YoutubeReExplode.Exceptions;
 /// <summary>
 /// Exception thrown when the requested playlist is unavailable.
 /// </summary>
-public class PlaylistUnavailableException : YoutubeExplodeException
+public class PlaylistUnavailableException : YoutubeReExplodeException
 {
     /// <summary>
     /// Initializes an instance of <see cref="PlaylistUnavailableException" />.

--- a/YoutubeReExplode/Exceptions/RequestLimitExceededException.cs
+++ b/YoutubeReExplode/Exceptions/RequestLimitExceededException.cs
@@ -3,7 +3,7 @@ namespace YoutubeReExplode.Exceptions;
 /// <summary>
 /// Exception thrown when YouTube denies a request because the client has exceeded rate limit.
 /// </summary>
-public class RequestLimitExceededException : YoutubeExplodeException
+public class RequestLimitExceededException : YoutubeReExplodeException
 {
     /// <summary>
     /// Initializes an instance of <see cref="RequestLimitExceededException" />.

--- a/YoutubeReExplode/Exceptions/VideoUnplayableException.cs
+++ b/YoutubeReExplode/Exceptions/VideoUnplayableException.cs
@@ -3,7 +3,7 @@ namespace YoutubeReExplode.Exceptions;
 /// <summary>
 /// Exception thrown when the requested video is unplayable.
 /// </summary>
-public class VideoUnplayableException : YoutubeExplodeException
+public class VideoUnplayableException : YoutubeReExplodeException
 {
     /// <summary>
     /// Initializes an instance of <see cref="VideoUnplayableException" />.

--- a/YoutubeReExplode/Exceptions/YoutubeReExplodeException.cs
+++ b/YoutubeReExplode/Exceptions/YoutubeReExplodeException.cs
@@ -5,13 +5,13 @@ namespace YoutubeReExplode.Exceptions;
 /// <summary>
 /// Exception thrown within <see cref="YoutubeReExplode" />.
 /// </summary>
-public class YoutubeExplodeException : Exception
+public class YoutubeReExplodeException : Exception
 {
     /// <summary>
-    /// Initializes an instance of <see cref="YoutubeExplodeException" />.
+    /// Initializes an instance of <see cref="YoutubeReExplodeException" />.
     /// </summary>
     /// <param name="message"></param>
-    public YoutubeExplodeException(string message) : base(message)
+    public YoutubeReExplodeException(string message) : base(message)
     {
     }
 }

--- a/YoutubeReExplode/Playlists/PlaylistClient.cs
+++ b/YoutubeReExplode/Playlists/PlaylistClient.cs
@@ -33,7 +33,7 @@ public class PlaylistClient
 
         var title =
             response.Title ??
-            throw new YoutubeExplodeException("Could not extract playlist title.");
+            throw new YoutubeReExplodeException("Could not extract playlist title.");
 
         // System playlists have no author
         var channelId = response.ChannelId;
@@ -49,15 +49,15 @@ public class PlaylistClient
         {
             var thumbnailUrl =
                 t.Url ??
-                throw new YoutubeExplodeException("Could not extract thumbnail URL.");
+                throw new YoutubeReExplodeException("Could not extract thumbnail URL.");
 
             var thumbnailWidth =
                 t.Width ??
-                throw new YoutubeExplodeException("Could not extract thumbnail width.");
+                throw new YoutubeReExplodeException("Could not extract thumbnail width.");
 
             var thumbnailHeight =
                 t.Height ??
-                throw new YoutubeExplodeException("Could not extract thumbnail height.");
+                throw new YoutubeReExplodeException("Could not extract thumbnail height.");
 
             var thumbnailResolution = new Resolution(thumbnailWidth, thumbnailHeight);
 
@@ -101,13 +101,13 @@ public class PlaylistClient
             {
                 var videoId =
                     videoData.Id ??
-                    throw new YoutubeExplodeException("Could not extract video ID.");
+                    throw new YoutubeReExplodeException("Could not extract video ID.");
 
                 lastVideoId = videoId;
 
                 lastVideoIndex =
                     videoData.Index ??
-                    throw new YoutubeExplodeException("Could not extract video index.");
+                    throw new YoutubeReExplodeException("Could not extract video index.");
 
                 // Don't yield the same video twice
                 if (!encounteredIds.Add(videoId))
@@ -121,25 +121,25 @@ public class PlaylistClient
 
                 var videoChannelTitle =
                     videoData.Author ??
-                    throw new YoutubeExplodeException("Could not extract video author.");
+                    throw new YoutubeReExplodeException("Could not extract video author.");
 
                 var videoChannelId =
                     videoData.ChannelId ??
-                    throw new YoutubeExplodeException("Could not extract video channel ID.");
+                    throw new YoutubeReExplodeException("Could not extract video channel ID.");
 
                 var videoThumbnails = videoData.Thumbnails.Select(t =>
                 {
                     var thumbnailUrl =
                         t.Url ??
-                        throw new YoutubeExplodeException("Could not extract thumbnail URL.");
+                        throw new YoutubeReExplodeException("Could not extract thumbnail URL.");
 
                     var thumbnailWidth =
                         t.Width ??
-                        throw new YoutubeExplodeException("Could not extract thumbnail width.");
+                        throw new YoutubeReExplodeException("Could not extract thumbnail width.");
 
                     var thumbnailHeight =
                         t.Height ??
-                        throw new YoutubeExplodeException("Could not extract thumbnail height.");
+                        throw new YoutubeReExplodeException("Could not extract thumbnail height.");
 
                     var thumbnailResolution = new Resolution(thumbnailWidth, thumbnailHeight);
 

--- a/YoutubeReExplode/Search/SearchClient.cs
+++ b/YoutubeReExplode/Search/SearchClient.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Common;
 using YoutubeReExplode.Exceptions;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Search;
 
@@ -56,7 +56,7 @@ public class SearchClient
 
                 var videoId =
                     videoData.Id ??
-                    throw new YoutubeExplodeException("Could not extract video ID.");
+                    throw new YoutubeReExplodeException("Could not extract video ID.");
 
                 // Don't yield the same result twice
                 if (!encounteredIds.Add(videoId))
@@ -64,33 +64,33 @@ public class SearchClient
 
                 var videoTitle =
                     videoData.Title ??
-                    throw new YoutubeExplodeException("Could not extract video title.");
+                    throw new YoutubeReExplodeException("Could not extract video title.");
 
                 var videoChannelTitle =
                     videoData.Author ??
-                    throw new YoutubeExplodeException("Could not extract video author.");
+                    throw new YoutubeReExplodeException("Could not extract video author.");
 
                 var videoChannelId =
                     videoData.ChannelId ??
-                    throw new YoutubeExplodeException("Could not extract video channel ID.");
+                    throw new YoutubeReExplodeException("Could not extract video channel ID.");
 
                 var isLive =
                     videoData.IsLive ??
-                    throw new YoutubeExplodeException("Could not extract video channel ID.");
+                    throw new YoutubeReExplodeException("Could not extract video channel ID.");
 
                 var videoThumbnails = videoData.Thumbnails.Select(t =>
                 {
                     var thumbnailUrl =
                         t.Url ??
-                        throw new YoutubeExplodeException("Could not extract video thumbnail URL.");
+                        throw new YoutubeReExplodeException("Could not extract video thumbnail URL.");
 
                     var thumbnailWidth =
                         t.Width ??
-                        throw new YoutubeExplodeException("Could not extract video thumbnail width.");
+                        throw new YoutubeReExplodeException("Could not extract video thumbnail width.");
 
                     var thumbnailHeight =
                         t.Height ??
-                        throw new YoutubeExplodeException("Could not extract video thumbnail height.");
+                        throw new YoutubeReExplodeException("Could not extract video thumbnail height.");
 
                     var thumbnailResolution = new Resolution(thumbnailWidth, thumbnailHeight);
 
@@ -121,7 +121,7 @@ public class SearchClient
 
                 var playlistId =
                     playlistData.Id ??
-                    throw new YoutubeExplodeException("Could not extract playlist ID.");
+                    throw new YoutubeReExplodeException("Could not extract playlist ID.");
 
                 // Don't yield the same result twice
                 if (!encounteredIds.Add(playlistId))
@@ -129,7 +129,7 @@ public class SearchClient
 
                 var playlistTitle =
                     playlistData.Title ??
-                    throw new YoutubeExplodeException("Could not extract playlist title.");
+                    throw new YoutubeReExplodeException("Could not extract playlist title.");
 
                 // System playlists have no author
                 var playlistAuthor =
@@ -142,15 +142,15 @@ public class SearchClient
                 {
                     var thumbnailUrl =
                         t.Url ??
-                        throw new YoutubeExplodeException("Could not extract playlist thumbnail URL.");
+                        throw new YoutubeReExplodeException("Could not extract playlist thumbnail URL.");
 
                     var thumbnailWidth =
                         t.Width ??
-                        throw new YoutubeExplodeException("Could not extract playlist thumbnail width.");
+                        throw new YoutubeReExplodeException("Could not extract playlist thumbnail width.");
 
                     var thumbnailHeight =
                         t.Height ??
-                        throw new YoutubeExplodeException("Could not extract playlist thumbnail height.");
+                        throw new YoutubeReExplodeException("Could not extract playlist thumbnail height.");
 
                     var thumbnailResolution = new Resolution(thumbnailWidth, thumbnailHeight);
 
@@ -178,25 +178,25 @@ public class SearchClient
 
                 var channelId =
                     channelData.Id ??
-                    throw new YoutubeExplodeException("Could not extract channel ID.");
+                    throw new YoutubeReExplodeException("Could not extract channel ID.");
 
                 var channelTitle =
                     channelData.Title ??
-                    throw new YoutubeExplodeException("Could not extract channel title.");
+                    throw new YoutubeReExplodeException("Could not extract channel title.");
 
                 var channelThumbnails = channelData.Thumbnails.Select(t =>
                 {
                     var thumbnailUrl =
                         t.Url ??
-                        throw new YoutubeExplodeException("Could not extract channel thumbnail URL.");
+                        throw new YoutubeReExplodeException("Could not extract channel thumbnail URL.");
 
                     var thumbnailWidth =
                         t.Width ??
-                        throw new YoutubeExplodeException("Could not extract channel thumbnail width.");
+                        throw new YoutubeReExplodeException("Could not extract channel thumbnail width.");
 
                     var thumbnailHeight =
                         t.Height ??
-                        throw new YoutubeExplodeException("Could not extract channel thumbnail height.");
+                        throw new YoutubeReExplodeException("Could not extract channel thumbnail height.");
 
                     var thumbnailResolution = new Resolution(thumbnailWidth, thumbnailHeight);
 

--- a/YoutubeReExplode/Utils/Http.cs
+++ b/YoutubeReExplode/Utils/Http.cs
@@ -10,7 +10,7 @@ internal static class Http
     {
         var handler = new HttpClientHandler
         {
-            // https://github.com/Tyrrrz/YoutubeReExplode/issues/530
+            // https://github.com/Tyrrrz/YoutubeExplode/issues/530
             UseCookies = false
         };
 

--- a/YoutubeReExplode/Videos/ClosedCaptions/ClosedCaptionClient.cs
+++ b/YoutubeReExplode/Videos/ClosedCaptions/ClosedCaptionClient.cs
@@ -7,8 +7,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Exceptions;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Videos.ClosedCaptions;
 
@@ -28,21 +28,22 @@ public class ClosedCaptionClient
         VideoId videoId,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var playerResponse = await _controller.GetPlayerResponseAsync(videoId, cancellationToken);
+        // Use the TVHTML5 client instead of ANDROID_TESTSUITE because the latter doesn't provide closed captions
+        var playerResponse = await _controller.GetPlayerResponseAsync(videoId, null, cancellationToken);
 
         foreach (var trackData in playerResponse.ClosedCaptionTracks)
         {
             var url =
                 trackData.Url ??
-                throw new YoutubeExplodeException("Could not extract track URL.");
+                throw new YoutubeReExplodeException("Could not extract track URL.");
 
             var languageCode =
                 trackData.LanguageCode ??
-                throw new YoutubeExplodeException("Could not extract track language code.");
+                throw new YoutubeReExplodeException("Could not extract track language code.");
 
             var languageName =
                 trackData.LanguageName ??
-                throw new YoutubeExplodeException("Could not extract track language name.");
+                throw new YoutubeReExplodeException("Could not extract track language name.");
 
             yield return new ClosedCaptionTrackInfo(
                 url,
@@ -70,11 +71,11 @@ public class ClosedCaptionClient
         {
             // Captions may have no text, but we should still include them to stay consistent
             // with YouTube player behavior where captions are still displayed even if they're empty.
-            // https://github.com/Tyrrrz/YoutubeReExplode/issues/671
+            // https://github.com/Tyrrrz/YoutubeExplode/issues/671
             var text = captionData.Text ?? "";
 
             // Auto-generated captions may be missing offset or duration.
-            // https://github.com/Tyrrrz/YoutubeReExplode/discussions/619
+            // https://github.com/Tyrrrz/YoutubeExplode/discussions/619
             if (captionData.Offset is not { } offset ||
                 captionData.Duration is not { } duration)
             {
@@ -85,12 +86,12 @@ public class ClosedCaptionClient
             {
                 // Caption parts may have no text, but we should still include them to stay consistent
                 // with YouTube player behavior where captions are still displayed even if they're empty.
-                // https://github.com/Tyrrrz/YoutubeReExplode/issues/671
+                // https://github.com/Tyrrrz/YoutubeExplode/issues/671
                 var partText = p.Text ?? "";
 
                 var partOffset =
                     p.Offset ??
-                    throw new YoutubeExplodeException("Could not extract caption part offset.");
+                    throw new YoutubeReExplodeException("Could not extract caption part offset.");
 
                 return new ClosedCaptionPart(partText, partOffset);
             }).ToArray();

--- a/YoutubeReExplode/Videos/ClosedCaptions/ClosedCaptionController.cs
+++ b/YoutubeReExplode/Videos/ClosedCaptions/ClosedCaptionController.cs
@@ -1,9 +1,9 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Bridge;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Videos.ClosedCaptions;
 

--- a/YoutubeReExplode/Videos/Music.cs
+++ b/YoutubeReExplode/Videos/Music.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace YoutubeReExplode.Videos;
 
 /// <summary>

--- a/YoutubeReExplode/Videos/Streams/StreamController.cs
+++ b/YoutubeReExplode/Videos/Streams/StreamController.cs
@@ -20,7 +20,7 @@ internal class StreamController : VideoController
 
         var version = Regex.Match(iframe, @"player\\?/([0-9a-fA-F]{8})\\?/").Groups[1].Value;
         if (string.IsNullOrWhiteSpace(version))
-            throw new YoutubeExplodeException("Could not extract player version.");
+            throw new YoutubeReExplodeException("Could not extract player version.");
 
         return PlayerSource.Parse(
             await Http.GetStringAsync(

--- a/YoutubeReExplode/Videos/Streams/VideoQuality.cs
+++ b/YoutubeReExplode/Videos/Streams/VideoQuality.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text.RegularExpressions;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Common;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode.Videos.Streams;
 

--- a/YoutubeReExplode/Videos/VideoClient.cs
+++ b/YoutubeReExplode/Videos/VideoClient.cs
@@ -59,38 +59,38 @@ public class VideoClient
 
         var channelTitle =
             playerResponse.Author ??
-            throw new YoutubeExplodeException("Could not extract video author.");
+            throw new YoutubeReExplodeException("Could not extract video author.");
 
         var channelId =
             playerResponse.ChannelId ??
-            throw new YoutubeExplodeException("Could not extract video channel ID.");
+            throw new YoutubeReExplodeException("Could not extract video channel ID.");
 
         var isLive =
             playerResponse.IsLive ??
-            throw new YoutubeExplodeException("Could not extract video live status.");
+            throw new YoutubeReExplodeException("Could not extract video live status.");
 
         var isLiveContent =
             playerResponse.IsLiveContent ??
-            throw new YoutubeExplodeException("Could not extract video livestream status.");
+            throw new YoutubeReExplodeException("Could not extract video livestream status.");
 
         var uploadDate =
             playerResponse.UploadDate ??
             watchPage.UploadDate ??
-            throw new YoutubeExplodeException("Could not extract video upload date.");
+            throw new YoutubeReExplodeException("Could not extract video upload date.");
 
         var thumbnails = playerResponse.Thumbnails.Select(t =>
         {
             var thumbnailUrl =
                 t.Url ??
-                throw new YoutubeExplodeException("Could not extract thumbnail URL.");
+                throw new YoutubeReExplodeException("Could not extract thumbnail URL.");
 
             var thumbnailWidth =
                 t.Width ??
-                throw new YoutubeExplodeException("Could not extract thumbnail width.");
+                throw new YoutubeReExplodeException("Could not extract thumbnail width.");
 
             var thumbnailHeight =
                 t.Height ??
-                throw new YoutubeExplodeException("Could not extract thumbnail height.");
+                throw new YoutubeReExplodeException("Could not extract thumbnail height.");
 
             var thumbnailResolution = new Resolution(thumbnailWidth, thumbnailHeight);
 

--- a/YoutubeReExplode/Videos/VideoController.cs
+++ b/YoutubeReExplode/Videos/VideoController.cs
@@ -19,7 +19,10 @@ internal class VideoController
         for (var retriesRemaining = 5;; retriesRemaining--)
         {
             var watchPage = VideoWatchPage.TryParse(
-                await Http.GetStringAsync($"https://www.youtube.com/watch?v={videoId}&bpctr=9999999999", cancellationToken)
+                await Http.GetStringAsync(
+                    $"https://www.youtube.com/watch?v={videoId}&bpctr=9999999999",
+                    cancellationToken
+                )
             );
 
             if (watchPage is null)
@@ -27,7 +30,7 @@ internal class VideoController
                 if (retriesRemaining > 0)
                     continue;
 
-                throw new YoutubeExplodeException(
+                throw new YoutubeReExplodeException(
                     "Video watch page is broken. " +
                     "Please try again in a few minutes."
                 );
@@ -44,6 +47,13 @@ internal class VideoController
         VideoId videoId,
         CancellationToken cancellationToken = default)
     {
+        // The most optimal client to impersonate is the Android client, because
+        // it doesn't require signature deciphering (for both normal and n-parameter signatures).
+        // However, the regular Android client has a limitation, preventing it from downloading
+        // multiple streams from the same manifest (or the same stream multiple times).
+        // As a workaround, we're using ANDROID_TESTSUITE which appears to offer the same
+        // functionality, but doesn't impose the aforementioned limitation.
+        // https://github.com/Tyrrrz/YoutubeExplode/issues/705
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://www.youtube.com/youtubei/v1/player")
         {
             Content = new StringContent(
@@ -52,8 +62,8 @@ internal class VideoController
                     "videoId": "{{videoId}}",
                     "context": {
                         "client": {
-                            "clientName": "ANDROID",
-                            "clientVersion": "17.10.35",
+                            "clientName": "ANDROID_TESTSUITE",
+                            "clientVersion": "1.9",
                             "androidSdkVersion": 30,
                             "hl": "en",
                             "gl": "US",
@@ -69,7 +79,7 @@ internal class VideoController
         // https://github.com/iv-org/invidious/issues/3230#issuecomment-1226887639
         request.Headers.Add(
             "User-Agent",
-            "com.google.android.youtube/17.10.35 (Linux; U; Android 12; GB) gzip"
+            "com.google.android.youtube/17.36.4 (Linux; U; Android 12; GB) gzip"
         );
 
         using var response = await Http.SendAsync(request, cancellationToken);
@@ -90,6 +100,9 @@ internal class VideoController
         string? signatureTimestamp,
         CancellationToken cancellationToken = default)
     {
+        // The only client that can handle age-restricted videos without authentication is the
+        // TVHTML5_SIMPLY_EMBEDDED_PLAYER client.
+        // This client does require signature deciphering, so we only use it as a fallback.
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://www.youtube.com/youtubei/v1/player")
         {
             Content = new StringContent(
@@ -110,7 +123,7 @@ internal class VideoController
                     },
                     "playbackContext": {
                         "contentPlaybackContext": {
-                            "signatureTimestamp": "{{signatureTimestamp}}"
+                            "signatureTimestamp": "{{signatureTimestamp ?? "19369"}}"
                         }
                     }
                 }

--- a/YoutubeReExplode/YoutubeHttpMessageHandler.cs
+++ b/YoutubeReExplode/YoutubeHttpMessageHandler.cs
@@ -2,9 +2,9 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using YoutubeReExplode.Utils.Extensions;
 using YoutubeReExplode.Exceptions;
 using YoutubeReExplode.Utils;
+using YoutubeReExplode.Utils.Extensions;
 
 namespace YoutubeReExplode;
 


### PR DESCRIPTION
* Use watch page as fallback for extracting video upload date

Closes #699

* Allow yielding videos without titles

Closes #700

* Update version

* Replace polyfills with PolyShim

* Update NuGet packages

* Remove `Microsoft.Bcl.HashCode`

* Update readme for the converter

* Move the warning up in the converter readme

* Update readme

* Update NuGet packages

* Update version

* fix: Fix broken pack step due to missing readme

* Refactor/upstream (#19)

* Update Android client version

* Remove a useless lock

* Use `ANDROID_TESTSUITE` instead of `ANDROID`

Closes #705

* Skip the "requires purchase" test

* Use the alternative client for requests related to closed captions

* Update version

* refactor: Optimize imports + Rename exception to match package name

---------



---------